### PR TITLE
Fix mouse yaw direction

### DIFF
--- a/index.html
+++ b/index.html
@@ -748,7 +748,7 @@ document.addEventListener('mousemove', (e) => {
   if (!started) return;
   let sensitivity = 0.003 / zoom;
   // Push mouse right → aim right, push mouse down → aim down
-  yaw += e.movementX * sensitivity;
+  yaw -= e.movementX * sensitivity;
   pitch -= e.movementY * sensitivity;
   pitch = clamp(pitch, -0.3, Math.PI / 2 - 0.05);
 });


### PR DESCRIPTION
### Motivation
- Horizontal mouse movement produced inverted camera yaw (moving mouse right panned the view left), so the control needed to be flipped to match expected input.

### Description
- Updated the mousemove handler in `index.html` to invert the horizontal update by using `yaw -= e.movementX * sensitivity` instead of adding, so moving the mouse right rotates the camera right.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ec71395148331b72a437fba32f74b)