### PR TITLE
Add round progression with themed backgrounds and visual polish

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,32 @@ let mouseX = 0, mouseY = 0;
 let hintTimer = 8000;
 let muzzleFlash = 0;
 let recoilT = 0;
+let round = 1;
+let themeIndex = 0;
+
+const THEMES = [
+  {
+    sky: ['#151525', '#23203d', '#3b2445', '#2a1520'],
+    ground: ['#2a3a20', '#1a2a15'],
+    stars: 'rgba(255,255,255,0.45)',
+    clouds: 'rgba(70,60,80,0.35)',
+    moon: 'rgba(240,230,200,0.9)',
+  },
+  {
+    sky: ['#0b1a2b', '#17334d', '#2b3f4d', '#1a2430'],
+    ground: ['#223833', '#132826'],
+    stars: 'rgba(200,230,255,0.4)',
+    clouds: 'rgba(80,100,120,0.35)',
+    moon: 'rgba(200,220,255,0.9)',
+  },
+  {
+    sky: ['#2a120f', '#3c1d1c', '#5a2a24', '#2a1511'],
+    ground: ['#3b2d1c', '#21170f'],
+    stars: 'rgba(255,220,200,0.35)',
+    clouds: 'rgba(90,70,60,0.35)',
+    moon: 'rgba(255,210,180,0.85)',
+  },
+];
 
 // World objects
 let zombies = [];
@@ -153,7 +179,7 @@ function generateWorld() {
   }
 
   // Zombies
-  for (let i = 0; i < CFG.ZOMBIE_COUNT; i++) {
+  for (let i = 0; i < zombieCountForRound(); i++) {
     spawnZombie();
   }
 
@@ -168,6 +194,20 @@ function generateWorld() {
       speed: rand(0.3, 1.2),
     });
   }
+}
+
+function zombieCountForRound() {
+  return CFG.ZOMBIE_COUNT + Math.floor((round - 1) * 4);
+}
+
+function applyRoundTheme() {
+  themeIndex = (round - 1) % THEMES.length;
+}
+
+function startNextRound() {
+  round += 1;
+  applyRoundTheme();
+  generateWorld();
 }
 
 function spawnZombie() {
@@ -222,6 +262,12 @@ let lastTime = 0;
 function update(dt) {
   if (!started) return;
 
+  const allDead = zombies.length > 0 && zombies.every(z => z.dead);
+  if (allDead) {
+    startNextRound();
+    return;
+  }
+
   // Update zombies
   for (let z of zombies) {
     if (z.dead) {
@@ -248,14 +294,8 @@ function update(dt) {
     }
   }
 
-  // Remove long-dead zombies and respawn
-  zombies = zombies.filter(z => {
-    if (z.dead && z.deathTimer > 15) {
-      spawnZombie();
-      return false;
-    }
-    return true;
-  });
+  // Remove long-dead zombies
+  zombies = zombies.filter(z => !(z.dead && z.deathTimer > 15));
 
   // Clouds
   for (let c of clouds) {
@@ -288,17 +328,18 @@ function update(dt) {
 
 // ─── DRAW ──────────────────────────────────────────────────
 function drawScene() {
+  const theme = THEMES[themeIndex];
   // Sky gradient
   let sky = ctx.createLinearGradient(0, 0, 0, H);
-  sky.addColorStop(0, '#1a1a2e');
-  sky.addColorStop(0.4, '#2d1b3d');
-  sky.addColorStop(0.7, '#4a2040');
-  sky.addColorStop(1, '#2a1520');
+  sky.addColorStop(0, theme.sky[0]);
+  sky.addColorStop(0.4, theme.sky[1]);
+  sky.addColorStop(0.7, theme.sky[2]);
+  sky.addColorStop(1, theme.sky[3]);
   ctx.fillStyle = sky;
   ctx.fillRect(0, 0, W, H);
 
   // Stars
-  ctx.fillStyle = 'rgba(255,255,255,0.4)';
+  ctx.fillStyle = theme.stars;
   for (let i = 0; i < 80; i++) {
     let sx = (Math.sin(i * 127.1) * 0.5 + 0.5) * W;
     let sy = (Math.cos(i * 311.7) * 0.3 + 0.1) * H;
@@ -311,8 +352,12 @@ function drawScene() {
     let mr = 30 * moonP.scale;
     if (mr > 2) {
       ctx.beginPath();
+      ctx.arc(moonP.x, moonP.y, mr * 2.2, 0, Math.PI * 2);
+      ctx.fillStyle = 'rgba(255,255,255,0.04)';
+      ctx.fill();
+      ctx.beginPath();
       ctx.arc(moonP.x, moonP.y, mr, 0, Math.PI * 2);
-      ctx.fillStyle = 'rgba(240,230,200,0.9)';
+      ctx.fillStyle = theme.moon;
       ctx.fill();
       ctx.beginPath();
       ctx.arc(moonP.x + mr * 0.25, moonP.y - mr * 0.1, mr * 0.85, 0, Math.PI * 2);
@@ -370,9 +415,17 @@ function drawScene() {
       case 'cloud': drawCloud(item.obj, item.proj); break;
     }
   }
+
+  // Vignette for mood
+  let vignette = ctx.createRadialGradient(W / 2, H / 2, Math.min(W, H) * 0.2, W / 2, H / 2, Math.max(W, H) * 0.7);
+  vignette.addColorStop(0, 'rgba(0,0,0,0)');
+  vignette.addColorStop(1, 'rgba(0,0,0,0.45)');
+  ctx.fillStyle = vignette;
+  ctx.fillRect(0, 0, W, H);
 }
 
 function drawGround() {
+  const theme = THEMES[themeIndex];
   // Render ground as grid of projected points
   let groundColor = '#2a3a20';
   let roadColor = '#3a3a35';
@@ -393,8 +446,8 @@ function drawGround() {
   }
   if (maxY > minY) {
     let grd = ctx.createLinearGradient(0, minY, 0, maxY);
-    grd.addColorStop(0, '#2a3a20');
-    grd.addColorStop(1, '#1a2a15');
+    grd.addColorStop(0, theme.ground[0]);
+    grd.addColorStop(1, theme.ground[1]);
     ctx.fillStyle = grd;
     ctx.fillRect(0, minY, W, maxY - minY + 50);
   }
@@ -554,12 +607,13 @@ function drawParticle(p, pp) {
 }
 
 function drawCloud(c, p) {
+  const theme = THEMES[themeIndex];
   let s = p.scale;
   let cw = c.w * s;
   let ch = c.h * s;
   ctx.beginPath();
   ctx.ellipse(p.x, p.y, Math.max(2, cw / 2), Math.max(1, ch / 2), 0, 0, Math.PI * 2);
-  ctx.fillStyle = 'rgba(60,50,70,0.3)';
+  ctx.fillStyle = theme.clouds;
   ctx.fill();
 }
 
@@ -622,10 +676,11 @@ function shoot() {
     let headP = project(z.x, z.height, z.z);
     if (!baseP || !headP) continue;
 
-    let dx = W / 2 - p.x;
-    let dy = H / 2 - p.y;
+    let cx = W / 2;
+    let cy = H / 2;
+    let dx = cx - p.x;
 
-    if (Math.abs(dx) < bodyW && dy > headP.y - H / 2 - bodyH * 0.15 && dy < baseP.y - H / 2) {
+    if (Math.abs(dx) < bodyW && cy > headP.y - bodyH * 0.15 && cy < baseP.y) {
       if (p.depth < closestDist) {
         closestDist = p.depth;
         closestZ = z;
@@ -748,7 +803,7 @@ document.addEventListener('mousemove', (e) => {
   if (!started) return;
   let sensitivity = 0.003 / zoom;
   // Push mouse right → aim right, push mouse down → aim down
-  yaw += e.movementX * sensitivity;
+  yaw -= e.movementX * sensitivity;
   pitch -= e.movementY * sensitivity;
   pitch = clamp(pitch, -0.3, Math.PI / 2 - 0.05);
 });
@@ -784,6 +839,7 @@ document.addEventListener('keydown', (e) => {
 
 // ─── MAIN LOOP ─────────────────────────────────────────────
 generateWorld();
+applyRoundTheme();
 
 function gameLoop(time) {
   let dt = Math.min((time - lastTime) / 1000, 0.05);


### PR DESCRIPTION
### Motivation
- Make the game progress through discrete rounds and vary the background so successive rounds feel different. 
- Improve the scene visuals (sky, moon, stars, clouds, ground, vignette) so the view is more attractive and atmospheric. 
- Ensure a round transitions automatically when all zombies are eliminated and stop auto-respawning zombies so rounds are meaningful. 

### Description
- Added `round`, `themeIndex` and a `THEMES` array, plus `zombieCountForRound()`, `applyRoundTheme()` and `startNextRound()` to track rounds, scale zombie counts, and cycle themes. 
- Updated `generateWorld()` to spawn `zombieCountForRound()` zombies and call `applyRoundTheme()` on startup to set the initial theme. 
- Changed `update()` to detect when all zombies are dead and call `startNextRound()`, and removed the previous long-dead automatic respawn behavior. 
- Polished background rendering: sky gradient, star color, moon glow, cloud tint, ground gradient and a radial vignette are now theme-driven and `drawCloud()`/`drawGround()` use theme colors; also added a subtle moon glow pass. 
- Minor gameplay fixes: `shoot()` center-hit vertical bounds now uses screen center `cy` for the head/base checks to make headshots register correctly, and the mouse `mousemove` yaw sign was adjusted for consistent aiming. 

### Testing
- Launched a simple HTTP server with `python -m http.server 8000` to serve the game, and the server started successfully. 
- Attempted an automated headless render/screenshot using Playwright (`playwright`), but the run failed due to the browser process crashing with a SIGSEGV / `TargetClosedError` and a timeout, so no screenshot was produced. 
- No unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ec71395148331b72a437fba32f74b)