### PR TITLE
Soften town density and add open fields for a more rural layout

### DIFF
--- a/game.js
+++ b/game.js
@@ -10,10 +10,10 @@ const CFG = {
     TOWN_RADIUS: 500,
     GROUND_Y: 0,
     BUILDING_COUNT: 18,
-    BLOCK_SIZE: 90,
-    STREET_WIDTH: 24,
-    DOWNTOWN_RADIUS: 180,
-    MIDTOWN_RADIUS: 320,
+    BLOCK_SIZE: 120,
+    STREET_WIDTH: 28,
+    DOWNTOWN_RADIUS: 140,
+    MIDTOWN_RADIUS: 260,
     BACKDROP_RADIUS: 760,
 };
 
@@ -143,6 +143,7 @@ function generateWorld() {
     createRoadGrid();
     createTownCore();
     createResidentialRing();
+    createOpenFields();
     createIndustrialLots();
     createBackdropTown();
 
@@ -198,24 +199,31 @@ function generateWorld() {
 }
 
 function createRoadGrid() {
-    const mainLen = CFG.TOWN_RADIUS * 2.2;
+    const mainLen = CFG.TOWN_RADIUS * 2.1;
     const mainWidth = CFG.STREET_WIDTH + 6;
     roads.push({ x: 0, z: 0, w: mainWidth, h: mainLen, type: 'road' });
     roads.push({ x: 0, z: 0, w: mainLen, h: mainWidth, type: 'road' });
 
     const spacing = CFG.BLOCK_SIZE + CFG.STREET_WIDTH;
-    for (let i = -3; i <= 3; i++) {
+    for (let i = -2; i <= 2; i++) {
         if (i === 0) continue;
         let offset = i * spacing;
         roads.push({ x: offset, z: 0, w: CFG.STREET_WIDTH, h: mainLen * 0.95, type: 'road' });
         roads.push({ x: 0, z: offset, w: mainLen * 0.95, h: CFG.STREET_WIDTH, type: 'road' });
     }
+
+    const ringDist = CFG.MIDTOWN_RADIUS + 70;
+    const ringLen = ringDist * 1.7;
+    roads.push({ x: 0, z: -ringDist, w: ringLen, h: CFG.STREET_WIDTH, type: 'road' });
+    roads.push({ x: 0, z: ringDist, w: ringLen, h: CFG.STREET_WIDTH, type: 'road' });
+    roads.push({ x: -ringDist, z: 0, w: CFG.STREET_WIDTH, h: ringLen, type: 'road' });
+    roads.push({ x: ringDist, z: 0, w: CFG.STREET_WIDTH, h: ringLen, type: 'road' });
 }
 
 function createTownCore() {
     const spacing = CFG.BLOCK_SIZE + CFG.STREET_WIDTH;
-    for (let gx = -3; gx <= 3; gx++) {
-        for (let gz = -3; gz <= 3; gz++) {
+    for (let gx = -2; gx <= 2; gx++) {
+        for (let gz = -2; gz <= 2; gz++) {
             if (gx === 0 && gz === 0) continue;
             let cx = gx * spacing;
             let cz = gz * spacing;
@@ -227,20 +235,52 @@ function createTownCore() {
 }
 
 function createResidentialRing() {
-    let rings = 18;
+    let rings = 10;
     for (let i = 0; i < rings; i++) {
         let angle = (i / rings) * Math.PI * 2 + rand(-0.2, 0.2);
-        let dist = rand(CFG.MIDTOWN_RADIUS + 40, CFG.MIDTOWN_RADIUS + 120);
+        let dist = rand(CFG.MIDTOWN_RADIUS + 70, CFG.MIDTOWN_RADIUS + 170);
         let cx = Math.cos(angle) * dist;
         let cz = Math.sin(angle) * dist;
         createNeighborhoodCluster(cx, cz);
     }
 }
 
+function createOpenFields() {
+    let patches = 10;
+    for (let i = 0; i < patches; i++) {
+        let angle = rand(0, Math.PI * 2);
+        let dist = rand(CFG.MIDTOWN_RADIUS + 40, CFG.TOWN_RADIUS - 120);
+        let cx = Math.cos(angle) * dist;
+        let cz = Math.sin(angle) * dist;
+        if (isBlocked(cx, cz, 60)) continue;
+
+        let treesCount = randInt(3, 7);
+        for (let t = 0; t < treesCount; t++) {
+            trees.push({
+                x: cx + rand(-55, 55),
+                z: cz + rand(-55, 55),
+                h: rand(18, 36),
+                trunkH: rand(6, 12),
+                radius: rand(10, 18),
+                type: Math.random() > 0.5 ? 'oak' : 'pine'
+            });
+        }
+
+        let bushesCount = randInt(8, 16);
+        for (let b = 0; b < bushesCount; b++) {
+            bushes.push({
+                x: cx + rand(-65, 65),
+                z: cz + rand(-65, 65),
+                size: rand(3, 6),
+                color: pick(['#2d4c1e', '#345a28', '#27401d'])
+            });
+        }
+    }
+}
+
 function createIndustrialLots() {
     let lots = [
-        { x: 420, z: 140 }, { x: -430, z: -120 },
-        { x: 380, z: -260 }, { x: -360, z: 260 }
+        { x: 420, z: 140 }, { x: -380, z: -180 }
     ];
     for (let lot of lots) {
         createIndustrialCluster(lot.x + rand(-25, 25), lot.z + rand(-25, 25));
@@ -274,8 +314,8 @@ function createBackdropTown() {
 function createTownBlock(cx, cz, zone) {
     let block = CFG.BLOCK_SIZE;
     let half = block / 2;
-    let buildingCount = zone === 'downtown' ? 6 : 4;
-    let inset = zone === 'downtown' ? 6 : 10;
+    let buildingCount = zone === 'downtown' ? 4 : 3;
+    let inset = zone === 'downtown' ? 10 : 14;
 
     for (let i = 0; i < buildingCount; i++) {
         let t = (i + 0.5) / buildingCount;
@@ -323,10 +363,10 @@ function createTownBlock(cx, cz, zone) {
 }
 
 function createNeighborhoodCluster(cx, cz) {
-    let count = randInt(4, 7);
+    let count = randInt(3, 5);
     for (let i = 0; i < count; i++) {
         let angle = rand(0, Math.PI * 2);
-        let dist = rand(8, 40);
+        let dist = rand(14, 52);
         let x = cx + Math.cos(angle) * dist;
         let z = cz + Math.sin(angle) * dist;
         createBuilding(x, z, rand(24, 36), rand(24, 36), 'residential');


### PR DESCRIPTION
### Motivation
- Reduce the claustrophobic, tightly-packed town layout and create a more rural/minecraft-like town with roads, houses and plenty of open space and greenery.

### Description
- Tuned core layout parameters in `game.js` by changing `BLOCK_SIZE` to `120`, `STREET_WIDTH` to `28`, `DOWNTOWN_RADIUS` to `140`, and `MIDTOWN_RADIUS` to `260` to favor larger blocks and more breathing room.
- Reduced downtown grid density and town core coverage by shrinking grid extents and iteration ranges and added a simple ring road in `createRoadGrid` to organize circulation without dense packing.
- Introduced `createOpenFields()` and invoked it from `generateWorld()` to place scattered tree and bush patches (open fields) between clusters to break up building massing.
- Lowered per-block/building density by decreasing `buildingCount` and increasing `inset` in `createTownBlock`, reduced neighborhood sizes and increased their spread, and trimmed down industrial lots.

### Testing
- Started a local server with `python -m http.server 8000` and ran a headless Playwright script to load `index.html` and capture a screenshot which completed and produced `artifacts/rural-town-layout.png`.
- Confirmed the modified `game.js` was staged and committed successfully with `git commit`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69820b1363788331a0818d82f5d0b8fa)